### PR TITLE
feat: add buffer time per service in addition to global one

### DIFF
--- a/app/Lists/translations_settings.php
+++ b/app/Lists/translations_settings.php
@@ -49,6 +49,8 @@ return [
     'service_f_sell' => __('Sell service', 'wappointment'),
     'service_f_sdecs' => __('Short description', 'wappointment'),
     'service_f_duration' => __('Durations', 'wappointment'),
+    'service_f_buffer' => __('Buffer time', 'wappointment'),
+    'service_f_buffer_tip' => __('Time (in minutes) reserved after this service to prepare for the next appointment. Leave at 0 to use the global default.', 'wappointment'),
     'service_f_modality' => __('Delivery modality', 'wappointment'),
     'service_f_cfield' => __('When client select this service, display the following fields', 'wappointment'),
     'service_f_countries' => __('Phone field accepted countries', 'wappointment'),

--- a/app/Models/CanBook.php
+++ b/app/Models/CanBook.php
@@ -39,7 +39,7 @@ trait CanBook
 
         $duration = $service->hasDuration($bookingRequest->get('duration'));
 
-        $end_at = $start_at + $this->getRealDuration(['duration' => $duration]);
+        $end_at = $start_at + $this->getRealDuration(['duration' => $duration, 'service' => $service]);
 
         $staff = !empty($bookingRequest->staff) ? $bookingRequest->staff : $bookingRequest->get('staff');
         if ($forceConfirmed) {

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -102,7 +102,21 @@ class Client extends Model
 
     protected function getRealDuration($service)
     {
-        return ((int) $service['duration'] + (int) Settings::get('buffer_time')) * 60;
+        return ((int) $service['duration'] + $this->resolveBufferTime($service)) * 60;
+    }
+
+    protected function resolveBufferTime($service)
+    {
+        if (is_array($service) && isset($service['service']) && is_object($service['service']) && method_exists($service['service'], 'getBufferTime')) {
+            return $service['service']->getBufferTime();
+        }
+        if (is_object($service) && method_exists($service, 'getBufferTime')) {
+            return $service->getBufferTime();
+        }
+        if (is_array($service) && isset($service['options']['buffer_time']) && $service['options']['buffer_time'] !== '') {
+            return (int) $service['options']['buffer_time'];
+        }
+        return (int) Settings::get('buffer_time');
     }
 
     public function mailableAddress()

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -4,6 +4,7 @@ namespace Wappointment\Models;
 
 use Wappointment\ClassConnect\Model;
 use Wappointment\ClassConnect\SoftDeletes;
+use Wappointment\Services\Settings;
 
 class Service extends Model
 {
@@ -68,5 +69,17 @@ class Service extends Model
                 return $duration_row['price_id'];
             }
         }
+    }
+
+    /**
+     * Per-service buffer time in minutes. Falls back to the global setting
+     * when the service does not define its own (incl. unmigrated services).
+     */
+    public function getBufferTime()
+    {
+        if (is_array($this->options) && isset($this->options['buffer_time']) && $this->options['buffer_time'] !== '') {
+            return (int) $this->options['buffer_time'];
+        }
+        return (int) Settings::get('buffer_time');
     }
 }

--- a/app/Services/AppointmentNew.php
+++ b/app/Services/AppointmentNew.php
@@ -53,6 +53,9 @@ class AppointmentNew
             'staff_id' => $staff_id_value,
             'package_id' => $client->bookingRequest->get('package_id'),
             'package_price_id' => $client->bookingRequest->get('package_price_id'),
+            'options' => ['buffer_time' => is_object($service) && method_exists($service, 'getBufferTime')
+                ? $service->getBufferTime()
+                : (int) Settings::get('buffer_time')],
         ], $client, $start_at, $service, $adminBooked);
 
         return static::bookCreate($appointmentData, $client, $forceConfirmed, $status, $adminBooked);
@@ -180,7 +183,11 @@ class AppointmentNew
             throw new \WappointmentException('Cannot book, data is invalid', 1);
         }
 
-        $data['options']['buffer_time'] = (int) Settings::get('buffer_time');
+        if (!isset($data['options']['buffer_time'])) {
+            $data['options']['buffer_time'] = (int) Settings::get('buffer_time');
+        } else {
+            $data['options']['buffer_time'] = (int) $data['options']['buffer_time'];
+        }
         return static::getAppointmentModel()::create($data);
     }
 

--- a/app/Services/Services.php
+++ b/app/Services/Services.php
@@ -39,6 +39,7 @@ class Services implements ServiceInterface
             'options' => '',
             'options.durations' => 'required|array',
             'options.durations.*.duration' => 'required|numeric',
+            'options.buffer_time' => 'numeric|min:0',
             'locations_id' => 'required',
         ];
 

--- a/resources/js/BookingForm/CalendarAbstract.vue
+++ b/resources/js/BookingForm/CalendarAbstract.vue
@@ -338,7 +338,17 @@ export default {
          * service slot duration in seconds
          */
         realSlotDuration(){
-            return (parseInt(this.duration) + parseInt(this.viewData.buffer_time)) *60
+            return (parseInt(this.duration) + parseInt(this.serviceBuffer())) *60
+        },
+
+        /**
+         * Per-service buffer when defined on the service, otherwise the global default.
+         */
+        serviceBuffer(){
+            if (this.service && this.service.options && this.service.options.buffer_time !== undefined && this.service.options.buffer_time !== '') {
+                return this.service.options.buffer_time
+            }
+            return this.viewData.buffer_time
         },
 
         setIntervals(start, end){

--- a/resources/js/CalendarAdmin/BehalfBooking.vue
+++ b/resources/js/CalendarAdmin/BehalfBooking.vue
@@ -306,7 +306,13 @@ export default {
             this.setDuration(this.durationSelectedFC)
         },
         realSlotDuration(duration){
-            return parseInt(duration) + parseInt(this.viewData.buffer_time) 
+            return parseInt(duration) + parseInt(this.serviceBuffer())
+        },
+        serviceBuffer(){
+            if (this.service && this.service.options && this.service.options.buffer_time !== undefined && this.service.options.buffer_time !== '') {
+                return this.service.options.buffer_time
+            }
+            return this.viewData.buffer_time
         },
         setDuration(duration){
             if(duration === false){

--- a/resources/js/Views/Subpages/ServiceNew.vue
+++ b/resources/js/Views/Subpages/ServiceNew.vue
@@ -93,7 +93,21 @@ export default {
                 required_options_props:{
                   'woo_sellable':'woo_sellable'
                 },
-               
+
+            },
+            {
+                type: 'duration',
+                label: this.get_i18n('service_f_buffer','settings'),
+                model: 'options.buffer_time',
+                cast: Number,
+                class: 'w-100',
+                default: 0,
+                min: 0,
+                max: 120,
+                step: 5,
+                int: true,
+                unit: 'min',
+                tip: this.get_i18n('service_f_buffer_tip','settings'),
             },
             {
                 type: 'opt-modality',


### PR DESCRIPTION
The buffer time was available only on global level but sometimes you need to set buffer time per each service. This change allows to set per service buffer time and always fallback to default buffer time (if any).